### PR TITLE
Feat/add write dynamo async option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ APP_NAME='talent-retainer-service'
 ENV_NAME='development'
 TIMEZONE='America/Sao_Paulo'
 ###################################
+# SPECIFIC OPTIONS
+###################################
+WRITE_OPERATION_LEVEL = 'ALL' # (ONLY_VALIDATE/ONLY_PERSIST/ALL) for scalability level and separate write ops
+###################################
 # AWS SERVICES
 ###################################
 AWS_ACCESS_KEY_ID='xxxx'

--- a/iaac/localstack/apigw.tf
+++ b/iaac/localstack/apigw.tf
@@ -82,6 +82,10 @@ resource "aws_api_gateway_method" "talent_get" {
   }
 
   authorization = "NONE"
+
+  lifecycle {
+    ignore_changes = ["request_parameters"]
+  }
 }
 
 resource "aws_api_gateway_integration" "talent_get" {
@@ -101,6 +105,10 @@ resource "aws_api_gateway_method" "talent_post" {
   http_method = "POST"
 
   authorization = "NONE"
+
+  lifecycle {
+    ignore_changes = ["request_parameters"]
+  }
 }
 
 resource "aws_api_gateway_integration" "talent_post" {
@@ -125,6 +133,10 @@ resource "aws_api_gateway_method" "talent_put" {
   }
 
   authorization = "NONE"
+
+  lifecycle {
+    ignore_changes = ["request_parameters"]
+  }
 }
 
 resource "aws_api_gateway_integration" "talent_put" {
@@ -136,6 +148,10 @@ resource "aws_api_gateway_integration" "talent_put" {
   type                    = "AWS_PROXY"
   passthrough_behavior    = "WHEN_NO_MATCH"
   uri                     = "${aws_lambda_function.talents_service.invoke_arn}"
+
+  lifecycle {
+    ignore_changes = ["timeout_milliseconds"] // problem with this parameter with localstack
+  }
 }
 
 resource "aws_api_gateway_method" "talent_delete" {
@@ -149,6 +165,10 @@ resource "aws_api_gateway_method" "talent_delete" {
   }
 
   authorization = "NONE"
+
+  lifecycle {
+    ignore_changes = ["request_parameters"]
+  }
 }
 
 resource "aws_api_gateway_integration" "talent_delete" {
@@ -213,6 +233,10 @@ resource "aws_api_gateway_method" "opening_get" {
   }
 
   authorization = "NONE"
+
+  lifecycle {
+    ignore_changes = ["request_parameters"]
+  }
 }
 
 resource "aws_api_gateway_integration" "opening_get" {
@@ -232,6 +256,10 @@ resource "aws_api_gateway_method" "opening_post" {
   http_method = "POST"
 
   authorization = "NONE"
+
+  lifecycle {
+    ignore_changes = ["request_parameters"]
+  }
 }
 
 resource "aws_api_gateway_integration" "opening_post" {
@@ -256,6 +284,10 @@ resource "aws_api_gateway_method" "opening_put" {
   }
 
   authorization = "NONE"
+
+  lifecycle {
+    ignore_changes = ["request_parameters"]
+  }
 }
 
 resource "aws_api_gateway_integration" "opening_put" {
@@ -280,6 +312,10 @@ resource "aws_api_gateway_method" "opening_delete" {
   }
 
   authorization = "NONE"
+
+  lifecycle {
+    ignore_changes = ["request_parameters"]
+  }
 }
 
 resource "aws_api_gateway_integration" "opening_delete" {

--- a/iaac/localstack/locals.tf
+++ b/iaac/localstack/locals.tf
@@ -25,6 +25,11 @@ locals {
     TIMEZONE = "America/Sao_Paulo"
 
     ###################################
+    # SPECIFIC OPTIONS
+    ###################################
+    WRITE_OPERATION_LEVEL = "ALL"
+
+    ###################################
     # AWS SERVICES
     ###################################
     # DYNAMO

--- a/src/adapters/index.js
+++ b/src/adapters/index.js
@@ -19,6 +19,8 @@ import talentAdapterFactory,
 // eslint-disable-next-line no-unused-vars
 { TalentAdapter } from './talent'
 
+import { EPersistOperation } from '../business/constants'
+
 import openingAdapterFactory,
 // eslint-disable-next-line no-unused-vars
 { OpeningAdapter } from './opening'
@@ -33,11 +35,12 @@ import openingAdapterFactory,
  * @param {QueueRepositoryInstance} queueTalentRepository repository instatiated for talent queue
  * @param {DynamoRepositoryInstance} openingRepository repository instatiated for opening table
  * @param {QueueRepositoryInstance} queueOpeningRepository repository instatiated for opening table queue
+ * @param {EPersistOperation} persistOperation option for persist operation (validate/persist/all) = default ALL
  * @returns {Adapter}
  */
-export const adapter = (escriba, talentRepository, queueTalentRepository, openingRepository, queueOpeningRepository) => {
+export const adapter = (escriba, talentRepository, queueTalentRepository, openingRepository, queueOpeningRepository, persistOperation = EPersistOperation.ALL) => {
   return {
-    talent: talentAdapterFactory(escriba, talentRepository, queueOpeningRepository),
-    opening: openingAdapterFactory(escriba, openingRepository, queueOpeningRepository)
+    talent: talentAdapterFactory(escriba, talentRepository, queueTalentRepository, persistOperation),
+    opening: openingAdapterFactory(escriba, openingRepository, queueOpeningRepository, persistOperation)
   }
 }

--- a/src/business/constants.js
+++ b/src/business/constants.js
@@ -1,3 +1,12 @@
+import {
+  EClassError,
+  throwCustomError,
+  // eslint-disable-next-line no-unused-vars
+  CustomError
+} from '../utils'
+
+import { not, isNil } from 'ramda'
+
 /**
  * Enum for ETalentStatus values.
  * @readonly
@@ -47,4 +56,32 @@ export const EOperation = {
   UPDATE: 'UPDATE', // update data in dynamo database
   DELETE: 'DELETE', // delete data in dynamo database
   MATCH: 'MATCH' // match between talents and openings
+}
+
+/**
+ * Enum for EPersistOperation values.
+ * @readonly
+ * @memberof business
+ * @enum {string}
+ */
+export const EPersistOperation = {
+  ONLY_VALIDATE: 'ONLY_VALIDATE', // only run validation and send to message queue to process in background
+  ALL: 'ALL' // (default) validate and persist
+}
+
+/**
+ * @description Validate if config from microservice use correct value
+ * @memberof business
+ * @function
+ * @throws {CustomError}
+ * @param {EPersistOperation} value value for validate
+ * @returns {EPersistOperation}
+ */
+export const validatePersistOperation = (value) => {
+  const methodPath = 'business.constants.validatePersistOperation'
+  if ((not(isNil(value)) && not(Object.values(EPersistOperation).includes(value)))) {
+    throwCustomError(new Error(`invalid value for EPersistOperation (type): got ${value}`), methodPath, EClassError.USER_ERROR)
+  }
+
+  return value
 }

--- a/src/business/constants.spec.js
+++ b/src/business/constants.spec.js
@@ -1,4 +1,13 @@
-import { ETalentRangeSalary, ETalentStatus, EOpeningStatus, EOperation } from './constants'
+import { ETalentRangeSalary, ETalentStatus, EOpeningStatus, EOperation, EPersistOperation, validatePersistOperation } from './constants'
+import { EClassError } from '../utils'
+import { throwCustomError } from '../utils/errors'
+
+/** mock error generation to validate signature */
+jest.mock('../utils/errors')
+
+throwCustomError.mockImplementation((error) => {
+  throw error
+})
 
 describe('constants', () => {
   test('ETalentStatus', () => {
@@ -24,5 +33,27 @@ describe('constants', () => {
     expect(EOperation.UPDATE).toBe('UPDATE')
     expect(EOperation.DELETE).toBe('DELETE')
     expect(EOperation.MATCH).toBe('MATCH')
+  })
+  test('EPersistOperation', () => {
+    expect(EPersistOperation.ONLY_VALIDATE).toBe('ONLY_VALIDATE')
+    expect(EPersistOperation.ALL).toBe('ALL')
+  })
+})
+
+describe('validatePersistOperation', () => {
+  test('validate invalid value', () => {
+    const value = 'INVALID'
+    const methodPath = 'business.constants.validatePersistOperation'
+    const throwMessage = `invalid value for EPersistOperation (type): got ${value}`
+    expect(() => {
+      validatePersistOperation(value)
+    }).toThrow(throwMessage)
+    // throws correct message
+    expect(throwCustomError).toHaveBeenCalledWith(new Error(throwMessage), methodPath, EClassError.USER_ERROR)
+  })
+
+  test('valid values', () => {
+    expect(validatePersistOperation(EPersistOperation.ALL)).toBe(EPersistOperation.ALL)
+    expect(validatePersistOperation(EPersistOperation.ONLY_VALIDATE)).toBe(EPersistOperation.ONLY_VALIDATE)
   })
 })

--- a/src/business/opening.js
+++ b/src/business/opening.js
@@ -67,14 +67,14 @@ export const validateCreateOpening = (data) => {
   }
 
   return {
+    // information from system
+    creationDate,
+    id: uuidv4(),
     // default values if is missing
     openingStatus: EOpeningStatus.OPEN,
     openingSalaryRange: ETalentRangeSalary.NONE,
     openingResume: '-',
-    ...data,
-    // information from system
-    creationDate,
-    id: uuidv4()
+    ...data
   }
 }
 
@@ -131,9 +131,9 @@ export const validateUpdateOpening = (data, originalData) => {
     .reduce(
       (reducedData, field) => R.dissoc(field, reducedData),
       {
+        lastUpdateDate,
         ...originalData,
-        ...data,
-        lastUpdateDate
+        ...data
       }
     )
 }

--- a/src/business/talent.js
+++ b/src/business/talent.js
@@ -67,14 +67,14 @@ export const validateCreateTalent = (data) => {
   }
 
   return {
+    // information from system
+    id: uuidv4(),
+    creationDate,
     // default values if is missing
     talentStatus: ETalentStatus.OPEN,
     talentLastSalaryRange: ETalentRangeSalary.NONE,
     talentResume: '-',
-    ...data,
-    // information from system
-    creationDate,
-    id: uuidv4()
+    ...data
   }
 }
 
@@ -131,9 +131,9 @@ export const validateUpdateTalent = (data, originalData) => {
     .reduce(
       (reducedData, field) => R.dissoc(field, reducedData),
       {
+        lastUpdateDate,
         ...originalData,
-        ...data,
-        lastUpdateDate
+        ...data
       }
     )
 }

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -77,6 +77,7 @@ const envProdName = 'production'
 const appConfig = {
   appName: getEnv('APP_NAME', 'talent-retainer-service'),
   isProduction: getEnv('NODE_ENV') === envProdName,
+  persistOperation: getEnv('WRITE_OPERATION_LEVEL', 'ALL'),
   envName: getEnv('NODE_ENV'),
   talent: {
     tableName: getEnv('AWS_DYNAMO_TALENT_TABLE_NAME', 'talent'),

--- a/src/ports/aws-lambda/openings.js
+++ b/src/ports/aws-lambda/openings.js
@@ -36,7 +36,7 @@ export const handler = async (event, context) => {
   const talentQueueRepoInstance = queueRepository(sqs, appConfig.talent.queueUrl)
   const openingQueueRepoInstance = queueRepository(sqs, appConfig.opening.queueUrl)
 
-  const adapterInstance = adapter(escriba, talentRepoInstance, talentQueueRepoInstance, openingRepoInstance, openingQueueRepoInstance)
+  const adapterInstance = adapter(escriba, talentRepoInstance, talentQueueRepoInstance, openingRepoInstance, openingQueueRepoInstance, appConfig.persistOperation)
 
   const getOpening = async () => {
     try {

--- a/src/ports/aws-lambda/talents.js
+++ b/src/ports/aws-lambda/talents.js
@@ -36,7 +36,7 @@ export const handler = async (event, context) => {
   const talentQueueRepoInstance = queueRepository(sqs, appConfig.talent.queueUrl)
   const openingQueueRepoInstance = queueRepository(sqs, appConfig.opening.queueUrl)
 
-  const adapterInstance = adapter(escriba, talentRepoInstance, talentQueueRepoInstance, openingRepoInstance, openingQueueRepoInstance)
+  const adapterInstance = adapter(escriba, talentRepoInstance, talentQueueRepoInstance, openingRepoInstance, openingQueueRepoInstance, appConfig.persistOperation)
 
   const getTalent = async () => {
     try {

--- a/src/ports/http/index.js
+++ b/src/ports/http/index.js
@@ -35,7 +35,7 @@ const talentRepoInstance = databaseRepository(dynamo, appConfig.talent.tableName
 const openingRepoInstance = databaseRepository(dynamo, appConfig.opening.tableName)
 const talentQueueRepoInstance = queueRepository(sqs, appConfig.talent.queueUrl)
 const openingQueueRepoInstance = queueRepository(sqs, appConfig.opening.queueUrl)
-const adapterInstance = adapter(escriba, talentRepoInstance, talentQueueRepoInstance, openingRepoInstance, openingQueueRepoInstance)
+const adapterInstance = adapter(escriba, talentRepoInstance, talentQueueRepoInstance, openingRepoInstance, openingQueueRepoInstance, appConfig.persistOperation)
 
 _app.use(bodyParser.json({ limit: '50mb' }))
 _app.use(bodyParser.urlencoded({ extended: false }))


### PR DESCRIPTION
this feature have two options


- ONLY_VALIDATE - the create/update/delete operation will send to queue, the worker will process async
- ALL - the create/update/delete will be sent to dynamo sync